### PR TITLE
Add p-queue for rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@hapi/hawk": "^7.1.0",
+    "@lifeomic/attempt": "^3.0.0",
     "@types/request-promise": "^4.1.44",
     "@types/request-promise-native": "^1.0.16",
     "axios": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   },
   "dependencies": {
     "@hapi/hawk": "^7.1.0",
-    "@lifeomic/attempt": "^3.0.0",
     "@types/request-promise": "^4.1.44",
     "@types/request-promise-native": "^1.0.16",
     "axios": "^0.18.0",
-    "axios-extensions": "^3.0.6"
+    "axios-extensions": "^3.0.6",
+    "p-queue": "^6.0.2"
   },
   "peerDependencies": {
     "@jupiterone/jupiter-managed-integration-sdk": "^23.0.2"

--- a/src/ThreatStackClient.ts
+++ b/src/ThreatStackClient.ts
@@ -9,7 +9,7 @@ import {
   IntegrationInstanceAuthorizationError,
   IntegrationLogger,
 } from "@jupiterone/jupiter-managed-integration-sdk";
-
+import { AttemptContext, retry } from "@lifeomic/attempt";
 import {
   ACCOUNT_ENTITY_CLASS,
   ACCOUNT_ENTITY_TYPE,
@@ -179,17 +179,42 @@ export default class ThreatStackClient {
 
     do {
       nextPageUrl = await this.requestQueue.add(async () => {
-        const { header } = Hawk.client.header(nextPageUrl, "GET", this.options);
-        const response = await this.axiosInstance.get<Page<T>>(nextPageUrl!, {
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: header,
-          },
-        });
+        return retry(
+          async () => {
+            const { header } = Hawk.client.header(
+              nextPageUrl,
+              "GET",
+              this.options,
+            );
+            const response = await this.axiosInstance.get<Page<T>>(
+              nextPageUrl!,
+              {
+                headers: {
+                  "Content-Type": "application/json",
+                  Authorization: header,
+                },
+              },
+            );
 
-        const page: any = response.data;
-        eachFn(page);
-        return page.token ? `${pagePrefix}token=${page.token}` : null;
+            const page: any = response.data;
+            eachFn(page);
+            return page.token ? `${pagePrefix}token=${page.token}` : null;
+          },
+          {
+            delay: 5000,
+            factor: 1.2,
+            maxAttempts: 15,
+            handleError(err: Error, context: AttemptContext) {
+              const axiosErr = err as axios.AxiosError;
+              if (axiosErr.response) {
+                const code = axiosErr.response.status;
+                if (code !== 429 && code !== 500) {
+                  context.abort();
+                }
+              }
+            },
+          },
+        );
       });
     } while (nextPageUrl);
   }

--- a/src/ThreatStackClient.ts
+++ b/src/ThreatStackClient.ts
@@ -1,5 +1,6 @@
 import * as axios from "axios";
 import { throttleAdapterEnhancer } from "axios-extensions";
+import PQueue from "p-queue";
 
 import * as Hawk from "@hapi/hawk";
 import {
@@ -8,7 +9,6 @@ import {
   IntegrationInstanceAuthorizationError,
   IntegrationLogger,
 } from "@jupiterone/jupiter-managed-integration-sdk";
-import { AttemptContext, retry } from "@lifeomic/attempt";
 
 import {
   ACCOUNT_ENTITY_CLASS,
@@ -87,6 +87,7 @@ export default class ThreatStackClient {
   private orgName: string;
   private orgId: string;
   private provider: string;
+  private requestQueue: PQueue;
 
   constructor(config: ThreatStackIntegrationConfig, logger: IntegrationLogger) {
     this.BASE_API_URL = `https://api.threatstack.com/v2`;
@@ -119,6 +120,11 @@ export default class ThreatStackClient {
       },
       logger,
     );
+
+    this.requestQueue = new PQueue({
+      interval: 60000,
+      intervalCap: 100,
+    });
   }
 
   public getAccountDetails(): ThreatStackAccountEntity {
@@ -172,40 +178,19 @@ export default class ThreatStackClient {
       : `${this.BASE_API_URL}/${firstUri}`;
 
     do {
-      nextPageUrl = await retry(
-        async () => {
-          const { header } = Hawk.client.header(
-            nextPageUrl,
-            "GET",
-            this.options,
-          );
-          const response = await this.axiosInstance.get<Page<T>>(nextPageUrl!, {
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: header,
-            },
-          });
-
-          const page: any = response.data;
-          eachFn(page);
-          return page.token ? `${pagePrefix}token=${page.token}` : null;
-        },
-        {
-          initialDelay: 1000,
-          delay: 5000,
-          factor: 1.2,
-          maxAttempts: 15,
-          handleError(err: Error, context: AttemptContext) {
-            const axiosErr = err as axios.AxiosError;
-            if (axiosErr.response) {
-              const code = axiosErr.response.status;
-              if (code !== 429 && code !== 500) {
-                context.abort();
-              }
-            }
+      nextPageUrl = await this.requestQueue.add(async () => {
+        const { header } = Hawk.client.header(nextPageUrl, "GET", this.options);
+        const response = await this.axiosInstance.get<Page<T>>(nextPageUrl!, {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: header,
           },
-        },
-      );
+        });
+
+        const page: any = response.data;
+        eachFn(page);
+        return page.token ? `${pagePrefix}token=${page.token}` : null;
+      });
     } while (nextPageUrl);
   }
 

--- a/src/executionHandler.ts
+++ b/src/executionHandler.ts
@@ -24,18 +24,6 @@ export default async function executionHandler(
 ): Promise<IntegrationExecutionResult> {
   const { graph, persister, provider } = initializeContext(context);
 
-  const [
-    oldAccountEntities,
-    oldAgentEntities,
-    oldAccountAgentRelationships,
-    oldVulnerabilityRelationships,
-  ] = await Promise.all([
-    graph.findAllEntitiesByType<ThreatStackAccountEntity>(ACCOUNT_ENTITY_TYPE),
-    graph.findEntitiesByType<ThreatStackAgentEntity>(AGENT_ENTITY_TYPE),
-    graph.findRelationshipsByType(ACCOUNT_AGENT_RELATIONSHIP_TYPE),
-    graph.findRelationshipsByType(AGENT_FINDING_RELATIONSHIP_TYPE),
-  ]);
-
   const [onlineAgents, offlineAgents, vulnerabilities] = await Promise.all([
     provider.getServerAgents("online"),
     provider.getServerAgents("offline"),
@@ -97,6 +85,18 @@ export default async function executionHandler(
       }
     }
   }
+
+  const [
+    oldAccountEntities,
+    oldAgentEntities,
+    oldAccountAgentRelationships,
+    oldVulnerabilityRelationships,
+  ] = await Promise.all([
+    graph.findAllEntitiesByType<ThreatStackAccountEntity>(ACCOUNT_ENTITY_TYPE),
+    graph.findEntitiesByType<ThreatStackAgentEntity>(AGENT_ENTITY_TYPE),
+    graph.findRelationshipsByType(ACCOUNT_AGENT_RELATIONSHIP_TYPE),
+    graph.findRelationshipsByType(AGENT_FINDING_RELATIONSHIP_TYPE),
+  ]);
 
   return {
     operations: await persister.publishPersisterOperations([

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,11 +915,6 @@
   resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-23.1.0.tgz#c52505ba3808cbe69f459f9dbeffa91a3a2472b9"
   integrity sha512-x7go4Ze3lx4D02mPvpcHSRI6ul94ng4qbUuc+cdrx1c6DVdiZfAN4loGNyHuw/mlHTveV3w/rzEkq/F5VLy8Dg==
 
-"@lifeomic/attempt@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@lifeomic/attempt/-/attempt-3.0.0.tgz#75fecc204f8b0ac18b5363b4404bb32450f01859"
-  integrity sha512-Ibk4Vfl46dSrhtH5fHsrTA4waAuyP7/qcr3uo0mO70azRc6LWgJILlMy3B1oOvyiN9jQcdqwsThaQkPKLiYKTg==
-
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -2057,6 +2052,11 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
+
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
 exec-sh@^0.3.2:
   version "0.3.2"
@@ -4293,10 +4293,25 @@ p-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.0.0.tgz#be18c5a5adeb8e156460651421aceca56c213a50"
   integrity sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w==
 
+p-queue@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.0.2.tgz#34ab9f1fe43b26ec6da2a94cae6b3c3cdcaecfde"
+  integrity sha512-KDmybfRp7PQXk6mRDCtbFWc1E6qUyIXLdmiCQbnKY8+DM0+PodWYLT4dPT/T4x4G+w4PHZXvMB3dZfLEI2vaFA==
+  dependencies:
+    eventemitter3 "^3.1.0"
+    p-timeout "^3.1.0"
+
 p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
   integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
+
+p-timeout@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.1.0.tgz#198c1f503bb973e9b9727177a276c80afd6851f3"
+  integrity sha512-C27DYI+tCroT8J8cTEyySGydl2B7FlxrGNF5/wmMbl1V+jeehUCzEE/BVgzRebdm2K3ZitKOKx8YbdFumDyYmw==
+  dependencies:
+    p-finally "^1.0.0"
 
 p-try@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,6 +915,11 @@
   resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-23.1.0.tgz#c52505ba3808cbe69f459f9dbeffa91a3a2472b9"
   integrity sha512-x7go4Ze3lx4D02mPvpcHSRI6ul94ng4qbUuc+cdrx1c6DVdiZfAN4loGNyHuw/mlHTveV3w/rzEkq/F5VLy8Dg==
 
+"@lifeomic/attempt@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lifeomic/attempt/-/attempt-3.0.0.tgz#75fecc204f8b0ac18b5363b4404bb32450f01859"
+  integrity sha512-Ibk4Vfl46dSrhtH5fHsrTA4waAuyP7/qcr3uo0mO70azRc6LWgJILlMy3B1oOvyiN9jQcdqwsThaQkPKLiYKTg==
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"


### PR DESCRIPTION
p-queue allows for limiting the number of requests the integration uses per minute, since there is a 200/min organization wide limit, and it allows for making the requests as quickly as possible. `retry` is still in place as well to handle the case where other actors consume the 200 limit, though the initial delay is removed and it doesn't wait quite as long to retry.