### PR TITLE
Update SDK to add logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,12 @@
   },
   "dependencies": {
     "@hapi/hawk": "^7.1.0",
+    "@jupiterone/jupiter-managed-integration-sdk": "^24.0.2",
     "@lifeomic/attempt": "^3.0.0",
     "axios": "^0.19.0",
     "axios-extensions": "^3.0.6",
     "node-fetch": "^2.6.0",
     "p-queue": "^6.0.2"
-  },
-  "peerDependencies": {
-    "@jupiterone/jupiter-managed-integration-sdk": "^24.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -45,7 +43,6 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-typescript": "^7.1.0",
-    "@jupiterone/jupiter-managed-integration-sdk": "^24.0.1",
     "@types/bunyan": "^1.8.5",
     "@types/fs-extra": "^7.0.0",
     "@types/jest": "^24.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import {
   IntegrationError,
   IntegrationInvocationConfig,
   IntegrationStepExecutionContext,
+  IntegrationStepInvocationEvent,
 } from "@jupiterone/jupiter-managed-integration-sdk";
 
 import initializeContext from "./initializeContext";
@@ -11,7 +12,24 @@ import fetchBatchOfAgents from "./threatstack/fetchBatchOfAgents";
 import fetchBatchOfVulnerabilities from "./threatstack/fetchBatchOfVulnerabilities";
 
 const invocationConfig: IntegrationInvocationConfig = {
+  instanceConfigFields: {
+    orgName: {
+      type: "string",
+    },
+    orgId: {
+      type: "string",
+    },
+    userId: {
+      type: "string",
+    },
+    apiKey: {
+      type: "string",
+      mask: true,
+    },
+  },
+
   invocationValidator,
+
   integrationStepPhases: [
     {
       steps: [
@@ -21,15 +39,9 @@ const invocationConfig: IntegrationInvocationConfig = {
           executionHandler: async (
             executionContext: IntegrationStepExecutionContext,
           ) => {
-            const iterationState = executionContext.event.iterationState;
-            if (!iterationState) {
-              throw new IntegrationError(
-                "Expected iterationState not found in event!",
-              );
-            }
             return fetchBatchOfAgents(
               await initializeContext(executionContext),
-              iterationState,
+              getIterationState(executionContext.event),
               "online",
             );
           },
@@ -44,15 +56,9 @@ const invocationConfig: IntegrationInvocationConfig = {
           executionHandler: async (
             executionContext: IntegrationStepExecutionContext,
           ) => {
-            const iterationState = executionContext.event.iterationState;
-            if (!iterationState) {
-              throw new IntegrationError(
-                "Expected iterationState not found in event!",
-              );
-            }
             return fetchBatchOfAgents(
               await initializeContext(executionContext),
-              iterationState,
+              getIterationState(executionContext.event),
               "offline",
             );
           },
@@ -67,15 +73,9 @@ const invocationConfig: IntegrationInvocationConfig = {
           executionHandler: async (
             executionContext: IntegrationStepExecutionContext,
           ) => {
-            const iterationState = executionContext.event.iterationState;
-            if (!iterationState) {
-              throw new IntegrationError(
-                "Expected iterationState not found in event!",
-              );
-            }
             return fetchBatchOfVulnerabilities(
               await initializeContext(executionContext),
-              iterationState,
+              getIterationState(executionContext.event),
             );
           },
         },
@@ -91,5 +91,14 @@ const invocationConfig: IntegrationInvocationConfig = {
     },
   ],
 };
+
+function getIterationState(event: IntegrationStepInvocationEvent) {
+  const iterationState = event.iterationState;
+  if (!iterationState) {
+    throw new IntegrationError("Expected iterationState not found in event!");
+  } else {
+    return iterationState;
+  }
+}
 
 export default invocationConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -899,10 +899,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@jupiterone/jupiter-managed-integration-sdk@^24.0.1":
-  version "24.0.1"
-  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-24.0.1.tgz#c1a0d42d16ebdb42f5b08043f057e471637c7667"
-  integrity sha512-xZHjFHlzSKjb2Uxz9dTmaL0IT0PBHPMZkZ1gsuq3vGwM15EXohxN3cDuQ6benaFksi3cQXoncSwy9wr/jdDzMA==
+"@jupiterone/jupiter-managed-integration-sdk@^24.0.2":
+  version "24.0.2"
+  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-24.0.2.tgz#e289906ad83f70fdef24e5216d6d5d11e43a7d6c"
+  integrity sha512-Ckhr8u7aO/Zx6mhdE5z82psjny5r8sGq+Wi/iyAk9GgrUqcOopoLaD3jrVNhsOJxoQZsAP0MS5YJYlQ3TbSVRQ==
 
 "@lifeomic/attempt@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
Updates to latest SDK to add support for logging non-sensitive config values to help with debugging.

Note that this places the package into `dependencies` and removes it from elsewhere so that it is transitive to the deployment projects, which will move to stop including the dependency directly, in order that there will be a single version of the SDK in the deployed project and Renovate will stop updating it in the deployed projects without also getting an update of the integration code.