### PR TITLE
Refactor to minimize memory usage

### DIFF
--- a/src/converters.ts
+++ b/src/converters.ts
@@ -128,9 +128,7 @@ export function createAgentFindingMappedRelationship(
       sourceEntityKey: agent._key,
       relationshipDirection: RelationshipDirection.FORWARD,
       targetFilterKeys: [["_type", "_key"]],
-      targetEntity: {
-        ...cve,
-      },
+      targetEntity: cve as any,
     },
   };
 }

--- a/src/initializeContext.ts
+++ b/src/initializeContext.ts
@@ -7,5 +7,6 @@ export default function initializeContext(
   return {
     ...context,
     ...context.clients.getClients(),
+    cache: context.clients.getCache(),
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import {
   EntityFromIntegration,
   GraphClient,
+  IntegrationCache,
   IntegrationExecutionContext,
   MappedRelationshipFromIntegration,
   PersisterClient,
@@ -31,6 +32,7 @@ export interface ThreatStackExecutionContext
   extends IntegrationExecutionContext {
   graph: GraphClient;
   persister: PersisterClient;
+  cache: IntegrationCache;
 }
 
 export interface ThreatStackAccountEntity extends EntityFromIntegration {


### PR DESCRIPTION
The goal here is to allow the process to reclaim memory by dereferencing data that is no longer needed. By pushing some work into smaller functions, when the frame is exited some memory can be reclaimed because those function scoped variables are not longer referenced. Additionally, the ids of the vulnerabilities are iterated and the data loaded in the loop so that not all the data is loaded into memory, but previous iterations can have their memory reclaimed.